### PR TITLE
CNAME: don't assume strings live long enough

### DIFF
--- a/intf6_.mod
+++ b/intf6_.mod
@@ -2579,7 +2579,9 @@ PROCEDURE cinit () {
   printf("Checking for possible seg error in double arrays: CTYPi==%d: ",CTYPi);
   printf("%d %g\n",dscrsz,dscr[dscrsz-1]); // scratch area for doubles
   for (i=0,j=0;i<CTYPi;i++) if (ctt(i,&name)!=0) {
-    cty[j]=i; CNAME[j]=name; ctymap[i]=j;
+    cty[j]=i;
+    CNAME[j]=strdup(name);
+    ctymap[i]=j;
     j++;
     if (j>=CTYPp) {printf("jitcondiv() INTERRA\n"); hxe();}
   }
@@ -2651,7 +2653,9 @@ PROCEDURE jitcondiv () {
   printf("%g %g ",DELM(CTYPi-1,CTYPi-1),DELD(CTYPi-1,CTYPi-1));
   printf("%d %g\n",dscrsz,dscr[dscrsz-1]); // scratch area for doubles
   for (i=0,j=0;i<CTYPi;i++) if (ctt(i,&name)!=0) {
-    cty[j]=i; CNAME[j]=name; ctymap[i]=j;
+    cty[j]=i;
+    CNAME[j]=strdup(name);
+    ctymap[i]=j;
     j++;
     if (j>=CTYPp) {printf("jitcondiv() INTERRA\n"); hxe();}
   }

--- a/network.hoc
+++ b/network.hoc
@@ -875,6 +875,8 @@ proc convwire () { local x,y,z,ii,jj,a,del,prid,prty,poid,poty,cv,cvt,dv,dvt,lse
     for prty=0,CTYPi-1 if (col.numc[prty]!=0 && (cv=int(col.conv[prty][poty]))>0){//go thru presynaptic types
       vrsz(MAXxy(2*cv,4*col.numc[prty]),v1,v2,v3)                
       {rdm.discunif(col.ix[prty],col.ixe[prty]) v3.setrand(rdm)}
+      // 2023-02-28: the use of an unitialised value of prid was causing inconsistent results between different versions of NEURON
+      prid = 0
       if(prty==poty) {v1.cull(v3,prid) v3.copy(v1) v2.resize(v3.size)} // get rid of self connect -- NB: prid wasn't set!! bug--fixit (poid==prid anyway)    
       if( (cnt=v3.uniq(l,1)) > cv){ cnt = cv } // puts unsorted uniq vals into v4
       vrsz(cnt,v2,v4,v5,v6,v7) // v4 has prids

--- a/readme.html
+++ b/readme.html
@@ -50,4 +50,7 @@ run on mac OS X.
 with the upcoming versions 8.2 and 9.0 of NEURON. Updated to use
 post ~2011 signature of mcell_ran4_init function and fix hashseed2
 argument.
+
+20230228 Fix to ensure printed strings are still valid, avoiding junk
+being printed in https://github.com/neuronsimulator/nrn-modeldb-ci
 </pre></html>


### PR DESCRIPTION
This caused intermittent failures as junk was sometimes printed to stdout.

The difference between this and https://github.com/ModelDBRepository/150245/pull/2 is that https://github.com/ModelDBRepository/150245/pull/2 also includes fixes for neuronsimulator/nrn#2027.